### PR TITLE
Make initial load forcable

### DIFF
--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/MigrateTo.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/MigrateTo.java
@@ -55,6 +55,7 @@ public abstract class MigrateTo extends AbstractSubcommand implements ISubcomman
 
 	private StreamOutput output;
 	private boolean listTagsOnly = false;
+	private boolean forceLoad = false;
 
 	private IProgressMonitor getMonitor() {
 		return new LogTaskMonitor(new StreamOutput(config.getContext().stdout()));
@@ -82,6 +83,11 @@ public abstract class MigrateTo extends AbstractSubcommand implements ISubcomman
 			if (subargs.hasOption(MigrateToOptions.OPT_RTC_LIST_TAGS_ONLY)) {
 				listTagsOnly = true;
 				output.writeLine("***** LIST ONLY THE TAGS *****");
+			}
+
+			if (subargs.hasOption(MigrateToOptions.OPT_RTC_FORCE_LOAD)) {
+				forceLoad = true;
+				output.writeLine("***** INITIAL LOAD IS FORCED *****");
 			}
 
 			final ScmCommandLineArgument sourceWsOption = ScmCommandLineArgument.create(
@@ -124,7 +130,7 @@ public abstract class MigrateTo extends AbstractSubcommand implements ISubcomman
 			migrator.init(sandboxDirectory);
 
 			RtcMigrator rtcMigrator = new RtcMigrator(output, config, destinationWsOption.getStringValue(), migrator,
-					sandboxDirectory);
+					sandboxDirectory, forceLoad);
 			boolean isFirstTag = true;
 			int numberOfTags = tags.size();
 			int tagCounter = 0;

--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/MigrateToOptions.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/MigrateToOptions.java
@@ -16,6 +16,7 @@ public class MigrateToOptions implements IOptionSource {
 
 	public static final IOptionKey OPT_RTC_CONNECTION_TIMEOUT = new OptionKey("timeout");
 	public static final IOptionKey OPT_RTC_LIST_TAGS_ONLY = new OptionKey("listTagsOnly");
+	public static final IOptionKey OPT_RTC_FORCE_LOAD = new OptionKey("listTagsOnly");
 
 	@Override
 	public Options getOptions() throws ConflictingOptionException {
@@ -33,6 +34,8 @@ public class MigrateToOptions implements IOptionSource {
 				"Timeout in seconds, default is 900");
 		options.addOption(new NamedOptionDefinition(OPT_RTC_LIST_TAGS_ONLY, "L", "list-tags-only", 0),
 				"List only all tags that would be migrated but do not migrate them.");
+		options.addOption(new NamedOptionDefinition(OPT_RTC_FORCE_LOAD, "f", "force", 0),
+				"Start load operations forced. This is sometimes required if the sandbox is not empty.");
 		return options;
 	}
 }

--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/RtcMigrator.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/RtcMigrator.java
@@ -28,14 +28,16 @@ public class RtcMigrator {
 	private final Migrator migrator;
 	private static final Set<String> initiallyLoadedComponents = new HashSet<String>();
 	private File sandboxDirectory;
+	private final boolean forceLoad;
 
 	public RtcMigrator(IChangeLogOutput output, IScmClientConfiguration config, String workspace, Migrator migrator,
-			File sandboxDirectory) {
+			File sandboxDirectory, boolean forceLoad) {
 		this.output = output;
 		this.config = config;
 		this.workspace = workspace;
 		this.migrator = migrator;
 		this.sandboxDirectory = sandboxDirectory;
+		this.forceLoad = forceLoad;
 	}
 
 	public void migrateTag(RtcTag tag) throws CLIClientException {
@@ -126,7 +128,7 @@ public class RtcMigrator {
 	private void handleInitialLoad(RtcChangeSet changeSet) {
 		if (!initiallyLoadedComponents.contains(changeSet.getComponent())) {
 			try {
-				new LoadCommandDelegate(config, output, workspace, changeSet.getComponent(), false).run();
+				new LoadCommandDelegate(config, output, workspace, changeSet.getComponent(), forceLoad).run();
 				initiallyLoadedComponents.add(changeSet.getComponent());
 			} catch (CLIClientException e) { // ignore
 				throw new RuntimeException("Not a valid sandbox. Please run [scm load " + workspace


### PR DESCRIPTION
Added -f / --force option to migration command. With -f set, the initial load is forced.
This could be necessary if the rtc sandbox is not empty.
