### PR TITLE
Never delete the root gitignore file

### DIFF
--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
@@ -212,6 +212,7 @@ public final class GitMigrator implements Migrator {
 
 	private void gitCommit(PersonIdent ident, String comment) {
 		try {
+			initRootGitignore(rootDir);
 			// add all untracked files
 			Status status = git.status().call();
 

--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
@@ -314,16 +314,18 @@ public final class GitMigrator implements Migrator {
 					String gitignoreFile = matcher.group(1).concat(".gitignore");
 					if (jazzIgnore.exists()) {
 						// change/add case
-						List<String> ignoreContent = JazzignoreTranslator.toGitignore(jazzIgnore);
-						Files.writeLines(new File(rootDir, gitignoreFile), ignoreContent, getCharset(), false);
-						additionalNames.add(gitignoreFile);
+						if (!".gitignore".equals(gitignoreFile)) {
+							List<String> ignoreContent = JazzignoreTranslator.toGitignore(jazzIgnore);
+							Files.writeLines(new File(rootDir, gitignoreFile), ignoreContent, getCharset(), false);
+							additionalNames.add(gitignoreFile);
+						}
 					} else {
 						// delete case except for root git ignore file
-						if(!".gitignore".equals(gitignoreFile)){
+						if (!".gitignore".equals(gitignoreFile)) {
 							new File(rootDir, gitignoreFile).delete();
 							additionalNames.add(gitignoreFile);
 						}
-					}					
+					}
 				}
 			}
 			// add additional modified name

--- a/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
+++ b/rtc2git.cli.extension/src/to/rtc/cli/migrate/git/GitMigrator.java
@@ -315,11 +315,14 @@ public final class GitMigrator implements Migrator {
 						// change/add case
 						List<String> ignoreContent = JazzignoreTranslator.toGitignore(jazzIgnore);
 						Files.writeLines(new File(rootDir, gitignoreFile), ignoreContent, getCharset(), false);
+						additionalNames.add(gitignoreFile);
 					} else {
-						// delete case
-						new File(rootDir, gitignoreFile).delete();
-					}
-					additionalNames.add(gitignoreFile);
+						// delete case except for root git ignore file
+						if(!".gitignore".equals(gitignoreFile)){
+							new File(rootDir, gitignoreFile).delete();
+							additionalNames.add(gitignoreFile);
+						}
+					}					
 				}
 			}
 			// add additional modified name


### PR DESCRIPTION
The root git ignore file has additional default items not to be deleted even though the corresponding aka the root jazz ignore file is deleted.